### PR TITLE
Fixed a couple instances where the buffer size was not being given

### DIFF
--- a/src/emstereolibpy/emstereolibpy.py
+++ b/src/emstereolibpy/emstereolibpy.py
@@ -134,7 +134,7 @@ def camera_file(cam: CameraID) -> str:
     :return:
     """
     p_buff = ctypes.create_string_buffer(b"", BUFF)
-    libc.GetCameraFile(cam, p_buff)
+    libc.GetCameraFile(cam, p_buff, BUFF)
     return p_buff.value.decode()
 
 
@@ -145,7 +145,7 @@ def camera_name(cam: CameraID) -> str:
     :return:
     """
     p_buff = ctypes.create_string_buffer(b"", BUFF)
-    libc.GetCameraName(cam, p_buff)
+    libc.GetCameraName(cam, p_buff, BUFF)
     return p_buff.value.decode()
 
 


### PR DESCRIPTION
Interesting that ctypes allows this. I think it just passes garbage down as the buffer size.

This was causing me to intermittently get the 'buffer too small' error from the C library for these calls. 